### PR TITLE
Add Python startup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ The project uses MongoDB to store product and container information.
 5. Visit `http://localhost:3000/health` to verify the database connection.
 6. (Optional) Seed example data with `npm run seed`.
 
+### Startup script
+
+If you don't have a MongoDB instance available, run `npm run startup`. This
+command launches an in-memory MongoDB server using a Python helper script and
+then starts the application.
+
 ### Generating and printing QR codes
 
 Run `npm run generate-qr` to create PNG QR codes for each container UUID. The

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node index.js",
     "dev": "nodemon index.js",
     "seed": "node seeds.js",
-    "generate-qr": "node scripts/generateQRCodes.js"
+    "generate-qr": "node scripts/generateQRCodes.js",
+    "startup": "python3 scripts/startup.py"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,7 @@
   "dependencies": {
     "dotenv": "^16.0.0",
     "express": "^4.18.2",
+    "mongodb-memory-server": "^10.1.4",
     "mongoose": "^7.0.0",
     "qrcode": "^1.5.4",
     "uuid": "^9.0.1"

--- a/scripts/memory_server.js
+++ b/scripts/memory_server.js
@@ -1,0 +1,18 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+(async () => {
+  try {
+    const mongod = await MongoMemoryServer.create();
+    console.log(mongod.getUri());
+    const cleanup = async () => {
+      await mongod.stop();
+      process.exit(0);
+    };
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+    // Keep process running
+    await new Promise(() => {});
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+
+def main():
+    mongo_uri = os.environ.get('MONGODB_URI')
+    memory_server = None
+
+    try:
+        if not mongo_uri:
+            memory_server = subprocess.Popen(
+                ['node', 'scripts/memory_server.js'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            mongo_uri = memory_server.stdout.readline().strip()
+            os.environ['MONGODB_URI'] = mongo_uri
+            print(f"Started in-memory MongoDB at {mongo_uri}")
+
+        server = subprocess.Popen(['node', 'index.js'], env=os.environ)
+        exit_code = server.wait()
+    finally:
+        if memory_server:
+            memory_server.terminate()
+            memory_server.wait()
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- convert the startup script to Python
- add a small Node helper to launch the in-memory MongoDB server
- expose the new Python script via `npm run startup`
- document the new Python-based startup script

## Testing
- `npm test` *(fails: no test specified)*
- `python3 scripts/startup.py` *(fails to download MongoDB binary)*

------
https://chatgpt.com/codex/tasks/task_e_68491bb6e8948325b5478df0302ea338