### PR TITLE
Split setup/startup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-MONGODB_URI=your-mongodb-connection-string
+MONGODB_URI=mongodb://localhost:27017
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -22,24 +22,21 @@ The project uses MongoDB to store product and container information.
 ## Prerequisites
 
 - Python 3
-- Running MongoDB instance (optional)
-- Environment variables for MongoDB connection
+- MongoDB installed locally (setup script will attempt installation)
 
 ## Setup
 
 1. Clone this repository.
-2. Run `python3 scripts/startup.py` to automatically install dependencies,
-   create a `.env` file if needed and launch the application. When no
-   `MONGODB_URI` is provided an in-memory MongoDB is used.
-3. Visit `http://localhost:3000/health` to verify the database connection.
-4. (Optional) Seed example data with `python3 seeds.py`.
+2. Run `python3 scripts/setup.py` to install dependencies, configure a local
+   MongoDB server and create a systemd service.
+3. Start the service with `python3 scripts/startup.py`.
+4. Visit `http://localhost:3000/health` to verify the database connection.
+5. (Optional) Seed example data with `python3 seeds.py`.
 
 ### Startup script
 
-The `python3 scripts/startup.py` command can be used at any time. It installs
-missing dependencies, copies `.env.example` to `.env` when necessary, starts an
-in-memory MongoDB server when `MONGODB_URI` is undefined and then launches the
-application.
+Use `python3 scripts/setup.py` once to configure the environment and service.
+Afterwards `python3 scripts/startup.py` simply starts the systemd service.
 
 ### Generating and printing QR codes
 

--- a/db.py
+++ b/db.py
@@ -1,6 +1,5 @@
 import os
 from pymongo import MongoClient
-import mongomock
 
 _db = None
 _client = None
@@ -11,11 +10,8 @@ def get_db():
     global _db, _client
     if _db is not None:
         return _db
-    uri = os.environ.get("MONGODB_URI")
+    uri = os.environ.get("MONGODB_URI", "mongodb://localhost:27017")
     db_name = os.environ.get("MONGODB_DB", "foodadmin")
-    if uri and not uri.startswith("mongomock://"):
-        _client = MongoClient(uri)
-    else:
-        _client = mongomock.MongoClient()
+    _client = MongoClient(uri)
     _db = _client.get_database(db_name)
     return _db

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Setup script to install dependencies, ensure MongoDB and configure the service."""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+import textwrap
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+SERVICE_FILE = '/etc/systemd/system/foodadmin.service'
+
+
+def get_dotenv_value(key: str) -> str:
+    env_path = PROJECT_DIR / '.env'
+    if not env_path.is_file():
+        return ''
+    with open(env_path) as env_file:
+        for line in env_file:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' in line:
+                k, v = line.split('=', 1)
+                if k.strip() == key:
+                    return v.strip()
+    return ''
+
+
+def ensure_dependencies() -> None:
+    """Install required Python packages."""
+    try:
+        import flask  # type: ignore
+        import pymongo  # type: ignore
+        import dotenv  # type: ignore
+    except Exception:
+        print('Installing Python dependencies...')
+        result = subprocess.run([
+            sys.executable,
+            '-m',
+            'pip',
+            'install',
+            '-r',
+            str(PROJECT_DIR / 'requirements.txt'),
+        ])
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+
+def ensure_env_file() -> None:
+    """Create .env from example if missing."""
+    env = PROJECT_DIR / '.env'
+    example = PROJECT_DIR / '.env.example'
+    if not env.exists() and example.exists():
+        shutil.copy(example, env)
+        print('Created .env from .env.example')
+
+
+def ensure_mongodb() -> None:
+    """Ensure MongoDB server is installed and running."""
+    if shutil.which('mongod') is None:
+        print('MongoDB server not found. Attempting to install...')
+        cmds = [
+            ['sudo', 'apt-get', 'update'],
+            ['sudo', 'apt-get', 'install', '-y', 'mongodb'],
+        ]
+        for cmd in cmds:
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print('Failed to install MongoDB. Please install it manually.')
+                return
+    subprocess.run(['sudo', 'systemctl', 'enable', '--now', 'mongod'])
+
+
+def create_service() -> None:
+    """Create the systemd service file if it does not exist."""
+    if os.path.isfile(SERVICE_FILE):
+        return
+
+    service_content = textwrap.dedent(f"""
+    [Unit]
+    Description=Food Admin Service
+    After=network.target mongod.service
+
+    [Service]
+    Type=simple
+    WorkingDirectory={PROJECT_DIR}
+    ExecStart=/usr/bin/python3 {PROJECT_DIR / 'app.py'}
+    Restart=always
+    EnvironmentFile={PROJECT_DIR / '.env'}
+
+    [Install]
+    WantedBy=multi-user.target
+    """)
+
+    with open('foodadmin.service', 'w') as f:
+        f.write(service_content)
+    subprocess.run(['sudo', 'mv', 'foodadmin.service', SERVICE_FILE])
+    subprocess.run(['sudo', 'systemctl', 'daemon-reload'])
+    subprocess.run(['sudo', 'systemctl', 'enable', 'foodadmin'])
+    print('Created systemd service at', SERVICE_FILE)
+
+
+def main() -> None:
+    ensure_env_file()
+    ensure_dependencies()
+
+    mongo_uri = os.environ.get('MONGODB_URI') or get_dotenv_value('MONGODB_URI')
+    if not mongo_uri or 'mongomock' in mongo_uri or mongo_uri.startswith('your-'):
+        print('MONGODB_URI is not configured. Defaulting to mongodb://localhost:27017')
+        mongo_uri = 'mongodb://localhost:27017'
+        os.environ['MONGODB_URI'] = mongo_uri
+
+    ensure_mongodb()
+    create_service()
+
+    print('Setup complete. Run `python3 scripts/startup.py` to start the service.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -1,58 +1,12 @@
 #!/usr/bin/env python3
-import os
-import shutil
+"""Start the Food Admin service."""
 import subprocess
 import sys
 
 
-def get_dotenv_value(key: str) -> str:
-    """Return value for key from .env file if present."""
-    if not os.path.isfile('.env'):
-        return ''
-    with open('.env') as env_file:
-        for line in env_file:
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if '=' in line:
-                k, v = line.split('=', 1)
-                if k.strip() == key:
-                    return v.strip()
-    return ''
-
-def ensure_dependencies():
-    """Install required Python packages when missing."""
-    try:
-        import flask  # type: ignore
-        import pymongo  # type: ignore
-        import dotenv  # type: ignore
-    except Exception:
-        print('Installing Python dependencies...')
-        result = subprocess.run([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.txt'])
-        if result.returncode != 0:
-            sys.exit(result.returncode)
-
-
-def ensure_env_file():
-    """Create .env from example if it doesn't exist."""
-    if not os.path.isfile('.env') and os.path.isfile('.env.example'):
-        shutil.copy('.env.example', '.env')
-        print('Created .env from .env.example')
-
-
-def main():
-    ensure_env_file()
-    ensure_dependencies()
-
-    mongo_uri = os.environ.get('MONGODB_URI') or get_dotenv_value('MONGODB_URI')
-    if not mongo_uri or mongo_uri.startswith('your-'):
-        mongo_uri = 'mongomock://localhost'
-        os.environ['MONGODB_URI'] = mongo_uri
-        print('Using in-memory MongoDB')
-
-    server = subprocess.Popen([sys.executable, 'app.py'], env=os.environ)
-    exit_code = server.wait()
-    sys.exit(exit_code)
+def main() -> None:
+    result = subprocess.run(['sudo', 'systemctl', 'start', 'foodadmin'])
+    sys.exit(result.returncode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- remove mongomock fallback and rely on local MongoDB
- add new setup script that installs dependencies, attempts to install MongoDB and creates a systemd unit
- simplify startup script to start the systemd service
- update example environment, README instructions

## Testing
- `python3 -m py_compile app.py db.py seeds.py services/*.py scripts/*.py`
- `python3 scripts/setup.py` *(fails: package mongodb has no installation candidate)*
- `python3 scripts/startup.py` *(fails: system not booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_6849c01ad6048325a211a73cdba9e50f