### PR TITLE
Remove Docker setup and init SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It helps you manage which products you own and where they are stored.
 
 ## Features
 
-The project uses MongoDB to store product and container information.
+The project uses SQLite to store product and container information.
 
 ### Product
 - `name` - product name
@@ -22,7 +22,6 @@ The project uses MongoDB to store product and container information.
 ## Prerequisites
 
 - Python 3
- - Docker (used to run MongoDB)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- drop all Docker/MongoDB helper functions from `scripts/setup.py`
- create SQLite database automatically and write a simplified systemd unit
- document that SQLite is used instead of MongoDB

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b7df3a2d08325b2304731143c83bc