### PR TITLE
Add pytest suite for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ The project uses SQLite to store product and container information.
 6. (Optional) Seed example data with `python3 seeds.py`.
 7. Retrieve the current inventory with `curl http://localhost:3000/containers`.
 
+## Running Tests
+
+Unit tests are located under the `tests/` directory and use `pytest`. Install
+pytest with `pip install pytest` if it is not already available and run:
+
+```bash
+pytest
+```
+
 ### Environment variables
 
 The `.env` file controls where data is stored and which port the service uses:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import sqlite3
+from pathlib import Path
+from typing import Generator
+
+import sys
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
+
+from db import _init_db
+
+
+@pytest.fixture()
+def db_conn() -> Generator[sqlite3.Connection, None, None]:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _init_db(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/tests/test_container_service.py
+++ b/tests/test_container_service.py
@@ -1,0 +1,41 @@
+from src.services import container_service, product_service
+
+
+def setup_product(conn):
+    return product_service.create_product(
+        conn,
+        {
+            "name": "Milk",
+            "upc": "456",
+            "uuid": "uuid2",
+            "nutrition": {"calories": 100},
+        },
+    )
+
+
+def test_create_list_update_delete_container(db_conn):
+    product = setup_product(db_conn)
+
+    container = container_service.create_container(
+        db_conn,
+        {
+            "product": product["id"],
+            "quantity": 1,
+            "opened": False,
+            "remaining": 1.0,
+        },
+    )
+    assert container["product"]["id"] == product["id"]
+    assert container["quantity"] == 1
+
+    containers = container_service.list_containers(db_conn)
+    assert len(containers) == 1
+
+    updated = container_service.update_container(
+        db_conn, container["id"], {"remaining": 0.5}
+    )
+    assert updated["remaining"] == 0.5
+
+    result = container_service.delete_container(db_conn, container["id"])
+    assert result is True
+    assert container_service.list_containers(db_conn) == []

--- a/tests/test_product_service.py
+++ b/tests/test_product_service.py
@@ -1,0 +1,25 @@
+from src.services import product_service
+
+
+def test_create_list_update_delete_product(db_conn):
+    data = {
+        "name": "Cheese",
+        "upc": "123",
+        "uuid": "uuid1",
+        "nutrition": {"calories": 50},
+    }
+    created = product_service.create_product(db_conn, data)
+    assert created["name"] == "Cheese"
+    assert created["nutrition"] == {"calories": 50}
+
+    products = product_service.list_products(db_conn)
+    assert len(products) == 1
+
+    updated = product_service.update_product(
+        db_conn, created["id"], {"name": "Cheddar"}
+    )
+    assert updated["name"] == "Cheddar"
+
+    result = product_service.delete_product(db_conn, created["id"])
+    assert result is True
+    assert product_service.list_products(db_conn) == []


### PR DESCRIPTION
## Summary
- add `tests/` directory with unit tests for product and container services
- show how to run pytest in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b82016f5483259f402da56c0d42b7