### PR TITLE
Add environment-based config and backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The project uses SQLite to store product and container information.
 5. Visit `http://localhost:3000/health` to verify the service is running.
 6. (Optional) Seed example data with `python3 seeds.py`.
 7. Retrieve the current inventory with `curl http://localhost:3000/containers`.
+8. Run `python3 scripts/backup.py` to create a timestamped backup in the
+   directory specified by `BACKUP_DIR`.
 
 ## Running Tests
 

--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Create a timestamped backup of the SQLite database."""
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from src import config
+from src.db import get_db
+
+
+def main() -> None:
+    db_url = config.get_database_url()
+    if not db_url.startswith("sqlite:///"):
+        raise SystemExit("Only SQLite backups are supported")
+
+    db_path = Path(db_url[len("sqlite:///") :])
+    if not db_path.exists():
+        raise SystemExit(f"Database file {db_path} does not exist")
+
+    backup_dir = config.get_backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_file = backup_dir / f"inventory_{timestamp}.db"
+    shutil.copy2(db_path, backup_file)
+    print(f"Backup written to {backup_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -6,28 +6,13 @@ import subprocess
 import sys
 from pathlib import Path
 import textwrap
-import sqlite3
+
+from src import config
 
 from src.db import get_db
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 SERVICE_FILE = "/etc/systemd/system/foodadmin.service"
-
-
-def get_dotenv_value(key: str) -> str:
-    env_path = PROJECT_DIR / ".env"
-    if not env_path.is_file():
-        return ""
-    with open(env_path) as env_file:
-        for line in env_file:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                k, v = line.split("=", 1)
-                if k.strip() == key:
-                    return v.strip()
-    return ""
 
 
 def ensure_dependencies() -> None:
@@ -109,12 +94,7 @@ def main() -> None:
     ensure_env_file()
     ensure_dependencies()
 
-    db_url = os.environ.get("DATABASE_URL") or get_dotenv_value("DATABASE_URL")
-    if not db_url or db_url.startswith("your-"):
-        print("DATABASE_URL is not configured. Defaulting to sqlite:///foodadmin.db")
-        db_url = "sqlite:///foodadmin.db"
-        os.environ["DATABASE_URL"] = db_url
-
+    db_url = config.get_database_url()
     init_database(db_url)
     create_service()
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_data_dir() -> Path:
+    """Return the directory for persistent data."""
+    data_dir = Path(os.environ.get("DATA_DIR", "./data"))
+    return data_dir
+
+
+def get_backup_dir() -> Path:
+    """Return the directory where backups should be stored."""
+    backup_dir = Path(os.environ.get("BACKUP_DIR", "./backups"))
+    return backup_dir
+
+
+def get_database_url() -> str:
+    """Return the configured database URL."""
+    default_path = get_data_dir() / "inventory.db"
+    return os.environ.get("DATABASE_URL", f"sqlite:///{default_path}")

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 import sqlite3
 from sqlite3 import Connection
 from typing import Optional
+
+from src import config
 
 _conn: Optional[Connection] = None
 
@@ -46,11 +48,13 @@ def get_db() -> Connection:
     if _conn is not None:
         return _conn
 
-    url = os.environ.get("DATABASE_URL", "sqlite:///foodadmin.db")
+    url = config.get_database_url()
     if url.startswith("sqlite:///"):
         path = url[len("sqlite:///") :]
     else:
         path = url
+
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
 
     _conn = sqlite3.connect(path, check_same_thread=False)
     _conn.row_factory = sqlite3.Row


### PR DESCRIPTION
## Summary
- load environment variables using `src.config`
- connect to SQLite using environment paths
- add backup script that writes to `BACKUP_DIR`
- document backup step in README

## Testing
- `pytest -q`
- `black -q .`


------
https://chatgpt.com/codex/tasks/task_e_684b831283108325866c602f7b01425e