### PR TITLE
Extend container fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The project uses SQLite to store product and container information.
 - `quantity` - how many units you own
 - `opened` - whether the container has been opened
 - `remaining` - amount left in the container
+- `expiration_date` - when the item expires
+- `location` - where the container is stored
+- `tags` - labels for categorization
+- `container_weight` - weight of the empty container
 
 ## Prerequisites
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, List, Optional
+from pydantic import BaseModel
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
@@ -9,6 +10,22 @@ from sqlite3 import Connection
 
 from src.db import get_db
 from src.services import container_service
+
+
+class ContainerCreate(BaseModel):
+    product: Optional[Any] = None
+    quantity: Optional[int] = None
+    opened: Optional[bool] = None
+    remaining: Optional[float] = None
+    expiration_date: Optional[str] = None
+    location: Optional[str] = None
+    tags: Optional[List[str]] = None
+    container_weight: Optional[int] = None
+
+
+class ContainerUpdate(ContainerCreate):
+    pass
+
 
 app = FastAPI()
 
@@ -32,13 +49,17 @@ def list_containers(db: Connection = Depends(db_conn)) -> Any:
 
 
 @app.post("/containers", status_code=201)
-def create_container(data: dict, db: Connection = Depends(db_conn)) -> Any:
-    return container_service.create_container(db, data)
+def create_container(data: ContainerCreate, db: Connection = Depends(db_conn)) -> Any:
+    return container_service.create_container(db, data.dict(exclude_unset=True))
 
 
 @app.patch("/containers/{id}")
-def update_container(id: Any, data: dict, db: Connection = Depends(db_conn)) -> Any:
-    container = container_service.update_container(db, id, data)
+def update_container(
+    id: Any, data: ContainerUpdate, db: Connection = Depends(db_conn)
+) -> Any:
+    container = container_service.update_container(
+        db, id, data.dict(exclude_unset=True)
+    )
     if not container:
         raise HTTPException(status_code=404, detail="Container not found")
     return container

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -26,6 +26,10 @@ def add_container(args: argparse.Namespace) -> None:
         "quantity": args.quantity,
         "opened": args.opened,
         "remaining": args.remaining,
+        "expiration_date": args.expiration_date,
+        "location": args.location,
+        "tags": args.tags.split(",") if args.tags else None,
+        "container_weight": args.container_weight,
     }
     container = container_service.create_container(conn, data)
     print(container)
@@ -42,6 +46,14 @@ def update_container(args: argparse.Namespace) -> None:
         data["opened"] = args.opened
     if args.remaining is not None:
         data["remaining"] = args.remaining
+    if args.expiration_date is not None:
+        data["expiration_date"] = args.expiration_date
+    if args.location is not None:
+        data["location"] = args.location
+    if args.tags is not None:
+        data["tags"] = args.tags.split(",") if args.tags else None
+    if args.container_weight is not None:
+        data["container_weight"] = args.container_weight
     container = container_service.update_container(conn, args.id, data)
     print(container)
 
@@ -64,6 +76,10 @@ def build_parser() -> argparse.ArgumentParser:
     add_cmd.add_argument("--quantity", type=int, required=False)
     add_cmd.add_argument("--opened", action="store_true")
     add_cmd.add_argument("--remaining", type=float, required=False)
+    add_cmd.add_argument("--expiration-date", required=False)
+    add_cmd.add_argument("--location", required=False)
+    add_cmd.add_argument("--tags", required=False)
+    add_cmd.add_argument("--container-weight", type=int, required=False)
     add_cmd.set_defaults(func=add_container)
 
     upd_cmd = sub.add_parser("update", help="Update a container")
@@ -72,6 +88,10 @@ def build_parser() -> argparse.ArgumentParser:
     upd_cmd.add_argument("--quantity", type=int)
     upd_cmd.add_argument("--opened", type=bool)
     upd_cmd.add_argument("--remaining", type=float)
+    upd_cmd.add_argument("--expiration-date")
+    upd_cmd.add_argument("--location")
+    upd_cmd.add_argument("--tags")
+    upd_cmd.add_argument("--container-weight", type=int)
     upd_cmd.set_defaults(func=update_container)
 
     del_cmd = sub.add_parser("delete", help="Delete a container")

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -34,7 +34,11 @@ def _init_db(conn: Connection) -> None:
             quantity INTEGER,
             opened BOOLEAN,
             remaining REAL,
-            uuid TEXT
+            uuid TEXT,
+            expiration_date TEXT,
+            location TEXT,
+            tags TEXT,
+            container_weight INTEGER
         )
     """
     )

--- a/tests/test_container_service.py
+++ b/tests/test_container_service.py
@@ -23,18 +23,28 @@ def test_create_list_update_delete_container(db_conn):
             "quantity": 1,
             "opened": False,
             "remaining": 1.0,
+            "expiration_date": "2025-01-01",
+            "location": "pantry",
+            "tags": ["dairy"],
+            "container_weight": 200,
         },
     )
     assert container["product"]["id"] == product["id"]
     assert container["quantity"] == 1
+    assert container["tags"] == ["dairy"]
+    assert container["container_weight"] == 200
 
     containers = container_service.list_containers(db_conn)
     assert len(containers) == 1
 
     updated = container_service.update_container(
-        db_conn, container["id"], {"remaining": 0.5}
+        db_conn,
+        container["id"],
+        {"remaining": 0.5, "tags": ["dairy", "open"], "container_weight": 250},
     )
     assert updated["remaining"] == 0.5
+    assert updated["tags"] == ["dairy", "open"]
+    assert updated["container_weight"] == 250
 
     result = container_service.delete_container(db_conn, container["id"])
     assert result is True


### PR DESCRIPTION
## Summary
- track expiration, location, tags and container weight on containers
- expose these fields in the CLI and API
- support new columns in the database and service layer
- document container properties in the README
- update tests for the new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b86927450832580afc2e565fe8490