### PR TITLE
Fix unused imports and E203 whitespace

### DIFF
--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 
 from src import config
-from src.db import get_db
 
 
 def main() -> None:
@@ -15,7 +14,7 @@ def main() -> None:
     if not db_url.startswith("sqlite:///"):
         raise SystemExit("Only SQLite backups are supported")
 
-    db_path = Path(db_url[len("sqlite:///") :])
+    db_path = Path(db_url[len("sqlite:///"):])
     if not db_path.exists():
         raise SystemExit(f"Database file {db_path} does not exist")
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 import textwrap
+import importlib
 
 from src import config
 
@@ -18,10 +19,10 @@ SERVICE_FILE = "/etc/systemd/system/foodadmin.service"
 def ensure_dependencies() -> None:
     """Install required Python packages."""
     try:
-        import fastapi  # type: ignore
-        import uvicorn  # type: ignore
-        import dotenv  # type: ignore
-        import sqlalchemy  # type: ignore
+        importlib.import_module("fastapi")
+        importlib.import_module("uvicorn")
+        importlib.import_module("dotenv")
+        importlib.import_module("sqlalchemy")
     except Exception:
         print("Installing Python dependencies...")
         result = subprocess.run(
@@ -53,7 +54,7 @@ def init_database(db_url: str) -> None:
     if not db_url.startswith("sqlite:///"):
         return
 
-    path = Path(db_url[len("sqlite:///") :])
+    path = Path(db_url[len("sqlite:///"):])
     path.parent.mkdir(parents=True, exist_ok=True)
     os.environ["DATABASE_URL"] = db_url
     get_db().close()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -10,7 +10,6 @@ import uvicorn
 
 from src.db import get_db
 from src.services import container_service
-from src.api.app import app
 
 
 def serve(_: argparse.Namespace) -> None:

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -54,7 +54,7 @@ def get_db() -> Connection:
 
     url = config.get_database_url()
     if url.startswith("sqlite:///"):
-        path = url[len("sqlite:///") :]
+        path = url[len("sqlite:///"):]
     else:
         path = url
 


### PR DESCRIPTION
## Summary
- remove unused imports from CLI and backup scripts
- load packages dynamically in setup utility
- trim whitespace in SQLite path handling

## Testing
- `flake8 scripts/backup.py scripts/setup.py src/cli/main.py src/db/__init__.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9282bcd083259201154465555855