### PR TITLE
Add API and CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from db import _init_db
 
 @pytest.fixture()
 def db_conn() -> Generator[sqlite3.Connection, None, None]:
-    conn = sqlite3.connect(":memory:")
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
     conn.row_factory = sqlite3.Row
     _init_db(conn)
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,59 @@
+import json
+from fastapi.testclient import TestClient
+
+from src.api.app import app, db_conn as app_db_conn
+from src.services import product_service
+
+
+# reuse db_conn fixture from conftest
+
+def test_container_api_crud(db_conn):
+    # Override dependency to use in-memory db
+    app.dependency_overrides[app_db_conn] = lambda: db_conn
+    client = TestClient(app)
+
+    # create product for container reference
+    product = product_service.create_product(
+        db_conn,
+        {"name": "Bread", "upc": "111", "uuid": "uuid", "nutrition": {"cals": 50}},
+    )
+
+    # create container
+    resp = client.post(
+        "/containers",
+        json={
+            "product": product["id"],
+            "quantity": 1,
+            "tags": ["baked"],
+            "container_weight": 100,
+        },
+    )
+    assert resp.status_code == 201
+    container = resp.json()
+    assert container["product"]["id"] == product["id"]
+    container_id = container["id"]
+
+    # list containers
+    resp = client.get("/containers")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # update container
+    resp = client.patch(
+        f"/containers/{container_id}",
+        json={"quantity": 2, "tags": ["baked", "fresh"]},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["quantity"] == 2
+    assert data["tags"] == ["baked", "fresh"]
+
+    # delete container
+    resp = client.delete(f"/containers/{container_id}")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Container deleted"
+
+    # verify deleted
+    assert client.get("/containers").json() == []
+
+    app.dependency_overrides.clear()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,108 @@
+import os
+import json
+import tempfile
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from src.cli import main as cli_main
+
+
+def run_cli(args, monkeypatch, tmp_db):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_db}")
+    parser = cli_main.build_parser()
+    parsed = parser.parse_args(args)
+    outputs = []
+
+    def fake_print(obj):
+        outputs.append(obj)
+
+    monkeypatch.setattr("builtins.print", fake_print)
+    parsed.func(parsed)
+    return outputs
+
+
+@pytest.fixture()
+def tmp_db(tmp_path):
+    db = tmp_path / "test.db"
+    return db
+
+
+def test_cli_add_update_delete(monkeypatch, tmp_path, tmp_db):
+    add_out = run_cli(
+        [
+            "add",
+            "--product",
+            "1",
+            "--quantity",
+            "2",
+            "--tags",
+            "dairy",
+        ],
+        monkeypatch,
+        tmp_db,
+    )
+    added = add_out[0]
+    cid = added["id"]
+
+    update_out = run_cli(
+        ["update", str(cid), "--quantity", "3", "--tags", "dairy,open"],
+        monkeypatch,
+        tmp_db,
+    )
+    updated = update_out[0]
+    assert updated["quantity"] == 3
+    assert updated["tags"] == ["dairy", "open"]
+
+    delete_out = run_cli(["delete", str(cid)], monkeypatch, tmp_db)
+    assert delete_out[0] == {"deleted": True}
+
+
+def test_cli_update_extra_and_serve(monkeypatch, tmp_db):
+    add_out = run_cli([
+        "add",
+        "--product",
+        "2",
+        "--quantity",
+        "1",
+    ], monkeypatch, tmp_db)
+    cid = add_out[0]["id"]
+
+    update_out = run_cli(
+        [
+            "update",
+            str(cid),
+            "--product",
+            "3",
+            "--quantity",
+            "4",
+            "--opened",
+            "--remaining",
+            "0.75",
+            "--expiration-date",
+            "2025-12-12",
+            "--location",
+            "shelf",
+            "--tags",
+            "a,b",
+            "--container-weight",
+            "50",
+        ],
+        monkeypatch,
+        tmp_db,
+    )
+    up = update_out[0]
+    assert up["quantity"] == 4
+    assert up["location"] == "shelf"
+
+    called = {}
+
+    def fake_run(app, host, port):
+        called["app"] = app
+        called["host"] = host
+        called["port"] = port
+
+    monkeypatch.setattr(cli_main.uvicorn, "run", fake_run)
+    run_cli(["serve"], monkeypatch, tmp_db)
+    assert called["app"] == "src.api.app:app"

--- a/tests/test_container_service.py
+++ b/tests/test_container_service.py
@@ -49,3 +49,50 @@ def test_create_list_update_delete_container(db_conn):
     result = container_service.delete_container(db_conn, container["id"])
     assert result is True
     assert container_service.list_containers(db_conn) == []
+
+
+def test_update_container_all_fields(db_conn):
+    prod1 = setup_product(db_conn)
+    prod2 = product_service.create_product(
+        db_conn,
+        {"name": "Yogurt", "upc": "789", "uuid": "uuid3", "nutrition": None},
+    )
+
+    container = container_service.create_container(
+        db_conn,
+        {
+            "product": prod1["id"],
+            "quantity": 1,
+            "opened": False,
+            "remaining": 1.0,
+            "expiration_date": "2025-01-01",
+            "location": "fridge",
+            "tags": ["dairy"],
+            "container_weight": 200,
+        },
+    )
+
+    updated = container_service.update_container(
+        db_conn,
+        container["id"],
+        {
+            "product": prod2["id"],
+            "quantity": 2,
+            "opened": True,
+            "remaining": 0.5,
+            "uuid": container["uuid"],
+            "expiration_date": "2026-01-01",
+            "location": "pantry",
+            "tags": ["cultured"],
+            "container_weight": 250,
+        },
+    )
+
+    assert updated["product"]["id"] == prod2["id"]
+    assert updated["quantity"] == 2
+    assert bool(updated["opened"]) is True
+    assert updated["remaining"] == 0.5
+    assert updated["expiration_date"] == "2026-01-01"
+    assert updated["location"] == "pantry"
+    assert updated["tags"] == ["cultured"]
+    assert updated["container_weight"] == 250


### PR DESCRIPTION
## Summary
- add FastAPI endpoint tests using TestClient
- add CLI tests through argparse invocation
- extend container service tests for more coverage
- fix sqlite thread safety in test fixture

## Testing
- `pytest -q`
- `pytest --cov=src --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_684b959851ac83258dabd5c3a7df99a7