### PR TITLE
Add documentation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Food Admin is a simple project for tracking food inventory and containers.
 It helps you manage which products you own and where they are stored.
+See the [docs](docs/) directory for an overview of the architecture, setup instructions and usage examples.
 
 ## Features
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+This project exposes both a REST API and a command line interface built on the same Python services.
+
+- **API**: `src/api/app.py` uses FastAPI to provide HTTP endpoints for container operations.
+- **CLI**: `src/cli/main.py` offers subcommands for adding, updating and deleting containers as well as running the API server.
+- **Services**: Code under `src/services` implements the business logic and directly interfaces with the SQLite database defined in `src/db`.
+- **Database**: Storage uses SQLite by default and is configured through environment variables in `src/config.py`.
+
+The structure keeps the core logic isolated so that the API and CLI share the same functions for consistent behaviour.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# Setup Guide
+
+1. Clone the repository.
+2. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv .venv && source .venv/bin/activate
+   ```
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Copy `.env.example` to `.env` and adjust paths if necessary. The defaults place the SQLite database under `data/`.
+5. Run the setup script to create the database and systemd service:
+   ```bash
+   python3 scripts/setup.py
+   ```
+6. Start the service:
+   ```bash
+   python3 scripts/startup.py
+   ```
+7. Verify the API is running at [http://localhost:3000/health](http://localhost:3000/health).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,38 @@
+# Using the API and CLI
+
+## CLI
+
+Run commands through the module `src.cli.main`:
+
+```bash
+python -m src.cli.main add --product 1 --quantity 2 --opened
+python -m src.cli.main update 5 --no-opened
+python -m src.cli.main delete 5
+```
+
+The `serve` subcommand starts the API server locally:
+
+```bash
+python -m src.cli.main serve
+```
+
+## API
+
+With the server running, you can interact with the REST endpoints. Examples:
+
+- List containers: `GET /containers`
+- Create container:
+  ```bash
+  curl -X POST http://localhost:3000/containers \
+    -H 'Content-Type: application/json' \
+    -d '{"product": 1, "quantity": 1}'
+  ```
+- Update container:
+  ```bash
+  curl -X PATCH http://localhost:3000/containers/<id> \
+    -H 'Content-Type: application/json' \
+    -d '{"quantity": 3}'
+  ```
+- Delete container: `DELETE /containers/<id>`
+
+The API also exposes a `/health` endpoint for a simple status check.


### PR DESCRIPTION
## Summary
- add new documentation on architecture, setup and how to interact via API and CLI
- link to docs folder from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b96ee73b08325bd98a64ba0d9f2db