### PR TITLE
Add backup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The project uses SQLite to store product and container information.
 6. (Optional) Seed example data with `python3 scripts/seeds.py`.
 7. Retrieve the current inventory with `curl http://localhost:3000/containers`.
 8. Run `python3 scripts/backup.py` to create a timestamped backup in the
-   directory specified by `BACKUP_DIR`.
+   directory specified by `BACKUP_DIR`. See the [Backups section](docs/usage.md#backups)
+   in the usage guide for more details.
 
 ## CLI Usage
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,3 +36,15 @@ With the server running, you can interact with the REST endpoints. Examples:
 - Delete container: `DELETE /containers/<id>`
 
 The API also exposes a `/health` endpoint for a simple status check.
+
+## Backups
+
+The helper script `scripts/backup.py` creates a timestamped copy of the
+SQLite database. The destination directory is controlled by the
+`BACKUP_DIR` environment variable which defaults to `./backups`.
+
+Run the script whenever you want to capture a backup:
+
+```bash
+python3 scripts/backup.py
+```


### PR DESCRIPTION
## Summary
- document backup script in the usage guide
- link to backup section from setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b99c7d9ec8325bb59df3805a54805