### PR TITLE
Pin httpx version

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@
    ```bash
    python3 -m venv .venv && source .venv/bin/activate
    ```
-3. Install dependencies:
+3. Install dependencies (includes a pinned httpx version):
    ```bash
    pip install -r requirements.txt
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ fastapi
 uvicorn
 python-dotenv
 sqlalchemy
-httpx
+httpx~=0.27


### PR DESCRIPTION
## Summary
- pin `httpx` to the 0.27 compatible series
- note the pinned dependency in setup instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9eb03ed883259ad75a8c1d546010