### PR TITLE
Add cron backup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ The project uses SQLite to store product and container information.
 7. Retrieve the current inventory with `curl http://localhost:3000/containers`.
 8. Run `python3 scripts/backup.py` to create a timestamped backup in the
    directory specified by `BACKUP_DIR`. See the [Backups section](docs/usage.md#backups)
-   in the usage guide for more details.
+   in the usage guide for more details. To automate backups with cron,
+   follow the [scheduled backups instructions](docs/setup.md#scheduled-backups)
+   in the setup guide.
 
 ## CLI Usage
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,3 +19,15 @@
    python3 scripts/startup.py
    ```
 7. Verify the API is running at [http://localhost:3000/health](http://localhost:3000/health).
+
+## Scheduled Backups
+
+Automate database backups by running `scripts/backup.py` through cron. The script relies on the `DATA_DIR`, `DATABASE_URL` and `BACKUP_DIR` environment variables which should mirror your `.env` configuration.
+
+Example entry for a daily backup at 2 AM:
+
+```cron
+0 2 * * * cd /path/to/food-admin && /path/to/venv/bin/python scripts/backup.py
+```
+
+This keeps a timestamped copy of the SQLite database in `$BACKUP_DIR`.


### PR DESCRIPTION
## Summary
- document how to schedule `scripts/backup.py` with cron
- link cron section from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba6717f5883258e6085b57a563212