### PR TITLE
Fix script import ordering

### DIFF
--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -7,10 +7,10 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from src import config
-
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_DIR))
+
+from src import config
 
 
 def main() -> None:

--- a/scripts/seeds.py
+++ b/scripts/seeds.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 import sys
 
-from src.db import get_db
-from src.services import container_service, product_service
-
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_DIR))
+
+from src.db import get_db
+from src.services import container_service, product_service
 
 
 def run() -> None:

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -8,11 +8,11 @@ import importlib
 from pathlib import Path
 import sys
 
-from src import config
-from src.db import get_db
-
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_DIR))
+
+from src import config
+from src.db import get_db
 
 SERVICE_FILE = "/etc/systemd/system/foodadmin.service"
 


### PR DESCRIPTION
## Summary
- ensure scripts add PROJECT_DIR to `sys.path` before importing

## Testing
- `black scripts/setup.py scripts/seeds.py scripts/backup.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ba7c992f48325862d7abac1b0e832