### PR TITLE
Add UPC-based container entry flow

### DIFF
--- a/src/services/product_service.py
+++ b/src/services/product_service.py
@@ -43,6 +43,13 @@ def get_product_by_id(conn: Connection, id_: Any) -> Optional[Dict[str, Any]]:
     return _normalize(row)
 
 
+def get_product_by_upc(conn: Connection, upc: str) -> Optional[Dict[str, Any]]:
+    """Return a product by UPC code if it exists."""
+    cur = conn.execute("SELECT * FROM products WHERE upc = ?", (upc,))
+    row = cur.fetchone()
+    return _normalize(row)
+
+
 def list_products(conn: Connection) -> List[Dict[str, Any]]:
     cur = conn.execute("SELECT * FROM products")
     return [_normalize(row) for row in cur.fetchall()]

--- a/src/utils/unit_conversion.py
+++ b/src/utils/unit_conversion.py
@@ -1,0 +1,32 @@
+"""Simple helpers for unit conversion."""
+
+from __future__ import annotations
+
+import re
+
+
+def to_grams(size: str) -> float:
+    """Convert a size string to grams when possible."""
+    size = size.strip().lower()
+    match = re.match(r"([0-9]*\.?[0-9]+)\s*(\w+)", size)
+    if not match:
+        raise ValueError(f"Unrecognized size: {size}")
+    value = float(match.group(1))
+    unit = match.group(2)
+    if unit in {"g", "gram", "grams"}:
+        grams = value
+    elif unit in {"kg", "kilogram", "kilograms"}:
+        grams = value * 1000
+    elif unit in {"oz", "ounce", "ounces"}:
+        grams = value * 28.3495
+    elif unit in {"lb", "pound", "lbs", "pounds"}:
+        grams = value * 453.592
+    else:
+        raise ValueError(f"Unsupported unit: {unit}")
+    return grams
+
+
+def format_metric(size: str) -> str:
+    """Return a metric string in grams from the given size."""
+    grams = round(to_grams(size))
+    return f"{grams} g"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,3 +104,14 @@ def test_cli_update_extra_and_serve(monkeypatch, tmp_db):
     monkeypatch.setattr(cli_main.uvicorn, "run", fake_run)
     run_cli(["serve"], monkeypatch, tmp_db)
     assert called["app"] == "src.api.app:app"
+
+
+def test_cli_add_upc_flow(monkeypatch, tmp_db):
+    inputs = iter(["Granola", "16 oz", '{"calories": 100}', "2"])
+
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    outputs = run_cli(["add", "--upc", "999"], monkeypatch, tmp_db)
+    assert len(outputs) == 2
+    for out in outputs:
+        assert out["product"]["upc"] == "999"
+        assert out["product"]["nutrition"]["package_size"] == "454 g"


### PR DESCRIPTION
## Summary
- add `get_product_by_upc` helper
- implement UPC-driven workflow in CLI `add` command
- convert package size to metric units
- test new CLI flow

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504c0634808325a368ba997cd20a40