### PR TITLE
Refactor to separate inventory and product databases

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from starlette.concurrency import run_in_threadpool
 from sqlite3 import Connection
 
-from src.db import get_db
+from src.db import get_inventory_db, get_product_db
 from src.services import container_service
 
 
@@ -31,12 +31,16 @@ class ContainerUpdate(ContainerCreate):
 app = FastAPI()
 
 
-async def db_conn() -> Connection:
-    return get_db()
+async def inventory_conn() -> Connection:
+    return get_inventory_db()
+
+
+async def product_conn() -> Connection:
+    return get_product_db()
 
 
 @app.get("/health")
-async def health(db: Connection = Depends(db_conn)) -> JSONResponse:
+async def health(db: Connection = Depends(inventory_conn)) -> JSONResponse:
     try:
         await run_in_threadpool(db.execute, "SELECT 1")
         return JSONResponse({"status": "ok"})
@@ -45,26 +49,42 @@ async def health(db: Connection = Depends(db_conn)) -> JSONResponse:
 
 
 @app.get("/containers")
-async def list_containers(db: Connection = Depends(db_conn)) -> Any:
-    return await run_in_threadpool(container_service.list_containers, db)
+async def list_containers(
+    inv_db: Connection = Depends(inventory_conn),
+    prod_db: Connection = Depends(product_conn),
+) -> Any:
+    return await run_in_threadpool(
+        container_service.list_containers,
+        inv_db,
+        prod_db,
+    )
 
 
 @app.post("/containers", status_code=201)
 async def create_container(
-    data: ContainerCreate, db: Connection = Depends(db_conn)
+    data: ContainerCreate,
+    inv_db: Connection = Depends(inventory_conn),
+    prod_db: Connection = Depends(product_conn),
 ) -> Any:
     return await run_in_threadpool(
-        container_service.create_container, db, data.dict(exclude_unset=True)
+        container_service.create_container,
+        inv_db,
+        prod_db,
+        data.dict(exclude_unset=True),
     )
 
 
 @app.patch("/containers/{id}")
 async def update_container(
-    id: Any, data: ContainerUpdate, db: Connection = Depends(db_conn)
+    id: Any,
+    data: ContainerUpdate,
+    inv_db: Connection = Depends(inventory_conn),
+    prod_db: Connection = Depends(product_conn),
 ) -> Any:
     container = await run_in_threadpool(
         container_service.update_container,
-        db,
+        inv_db,
+        prod_db,
         id,
         data.dict(exclude_unset=True),
     )
@@ -74,10 +94,12 @@ async def update_container(
 
 
 @app.delete("/containers/{id}")
-async def delete_container(id: Any, db: Connection = Depends(db_conn)) -> Any:
+async def delete_container(
+    id: Any, inv_db: Connection = Depends(inventory_conn)
+) -> Any:
     deleted = await run_in_threadpool(
         container_service.delete_container,
-        db,
+        inv_db,
         id,
     )
     if deleted:

--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,21 @@ def get_backup_dir() -> Path:
     return backup_dir
 
 
-def get_database_url() -> str:
-    """Return the configured database URL."""
+def get_inventory_database_url() -> str:
+    """Return the configured inventory database URL."""
     default_path = get_data_dir() / "inventory.db"
-    return os.environ.get("DATABASE_URL", f"sqlite:///{default_path}")
+    return os.environ.get(
+        "INVENTORY_DATABASE_URL",
+        os.environ.get("DATABASE_URL", f"sqlite:///{default_path}"),
+    )
+
+
+def get_product_database_url() -> str:
+    """Return the configured products database URL."""
+    default_path = get_data_dir() / "products.db"
+    return os.environ.get("PRODUCT_DATABASE_URL", f"sqlite:///{default_path}")
+
+
+def get_database_url() -> str:
+    """Backward compatibility shim for inventory DB."""
+    return get_inventory_database_url()

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -9,11 +9,12 @@ from typing import Optional
 
 from src import config
 
-_conn: Optional[Connection] = None
+_inventory_conn: Optional[Connection] = None
+_product_conn: Optional[Connection] = None
 
 
-def _init_db(conn: Connection) -> None:
-    """Create tables if they do not already exist."""
+def _init_product_db(conn: Connection) -> None:
+    """Create products table if it does not already exist."""
 
     conn.execute(
         """
@@ -26,6 +27,12 @@ def _init_db(conn: Connection) -> None:
         )
     """
     )
+    conn.commit()
+
+
+def _init_inventory_db(conn: Connection) -> None:
+    """Create containers table if it does not already exist."""
+
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS containers (
@@ -45,14 +52,7 @@ def _init_db(conn: Connection) -> None:
     conn.commit()
 
 
-def get_db() -> Connection:
-    """Return an SQLite database connection."""
-
-    global _conn
-    if _conn is not None:
-        return _conn
-
-    url = config.get_database_url()
+def _connect(url: str) -> Connection:
     if url.startswith("sqlite:///"):
         start = len("sqlite:///")
         path = url[start:]
@@ -60,8 +60,40 @@ def get_db() -> Connection:
         path = url
 
     Path(path).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
 
-    _conn = sqlite3.connect(path, check_same_thread=False)
-    _conn.row_factory = sqlite3.Row
-    _init_db(_conn)
-    return _conn
+
+def get_inventory_db() -> Connection:
+    """Return the inventory database connection."""
+
+    global _inventory_conn
+    if _inventory_conn is None:
+        url = config.get_inventory_database_url()
+        _inventory_conn = _connect(url)
+        _init_inventory_db(_inventory_conn)
+    return _inventory_conn
+
+
+def get_product_db() -> Connection:
+    """Return the products database connection."""
+
+    global _product_conn
+    if _product_conn is None:
+        url = config.get_product_database_url()
+        _product_conn = _connect(url)
+        _init_product_db(_product_conn)
+    return _product_conn
+
+
+def _init_db(conn: Connection) -> None:
+    """Initialize both tables on a single connection."""
+
+    _init_product_db(conn)
+    _init_inventory_db(conn)
+
+
+def get_db() -> Connection:
+    """Backward compatibility shim for inventory DB."""
+    return get_inventory_db()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,10 @@
 from fastapi.testclient import TestClient
 
-from src.api.app import app, db_conn as app_db_conn
+from src.api.app import (
+    app,
+    inventory_conn as app_inventory_conn,
+    product_conn as app_product_conn,
+)
 from src.services import product_service
 
 
@@ -8,8 +12,9 @@ from src.services import product_service
 
 
 def test_container_api_crud(db_conn):
-    # Override dependency to use in-memory db
-    app.dependency_overrides[app_db_conn] = lambda: db_conn
+    # Override dependencies to use in-memory db
+    app.dependency_overrides[app_inventory_conn] = lambda: db_conn
+    app.dependency_overrides[app_product_conn] = lambda: db_conn
     client = TestClient(app)
 
     # create product for container reference

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from src.cli import main as cli_main
 
 def run_cli(args, monkeypatch, tmp_db):
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_db}")
+    monkeypatch.setenv("PRODUCT_DATABASE_URL", f"sqlite:///{tmp_db}")
     parser = cli_main.build_parser()
     parsed = parser.parse_args(args)
     outputs = []

--- a/tests/test_container_service.py
+++ b/tests/test_container_service.py
@@ -18,6 +18,7 @@ def test_create_list_update_delete_container(db_conn):
 
     container = container_service.create_container(
         db_conn,
+        db_conn,
         {
             "product": product["id"],
             "quantity": 1,
@@ -34,10 +35,11 @@ def test_create_list_update_delete_container(db_conn):
     assert container["tags"] == ["dairy"]
     assert container["container_weight"] == 200
 
-    containers = container_service.list_containers(db_conn)
+    containers = container_service.list_containers(db_conn, db_conn)
     assert len(containers) == 1
 
     updated = container_service.update_container(
+        db_conn,
         db_conn,
         container["id"],
         {"remaining": 0.5, "tags": ["dairy", "open"], "container_weight": 250},
@@ -48,7 +50,7 @@ def test_create_list_update_delete_container(db_conn):
 
     result = container_service.delete_container(db_conn, container["id"])
     assert result is True
-    assert container_service.list_containers(db_conn) == []
+    assert container_service.list_containers(db_conn, db_conn) == []
 
 
 def test_update_container_all_fields(db_conn):
@@ -59,6 +61,7 @@ def test_update_container_all_fields(db_conn):
     )
 
     container = container_service.create_container(
+        db_conn,
         db_conn,
         {
             "product": prod1["id"],
@@ -73,6 +76,7 @@ def test_update_container_all_fields(db_conn):
     )
 
     updated = container_service.update_container(
+        db_conn,
         db_conn,
         container["id"],
         {


### PR DESCRIPTION
## Summary
- add dedicated config helpers for product and inventory DB paths
- refactor db helpers to manage two SQLite connections
- update container service and CLI to use product/inventory databases
- adjust API dependencies
- update tests for new connection setup

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504b1c254c8325a9edf8d36bd284a6