### PR TITLE
Add interactive UPC flow to CLI

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -11,6 +11,8 @@ from src import config
 
 _inventory_conn: Optional[Connection] = None
 _product_conn: Optional[Connection] = None
+_inventory_url: Optional[str] = None
+_product_url: Optional[str] = None
 
 
 def _init_product_db(conn: Connection) -> None:
@@ -68,22 +70,24 @@ def _connect(url: str) -> Connection:
 def get_inventory_db() -> Connection:
     """Return the inventory database connection."""
 
-    global _inventory_conn
-    if _inventory_conn is None:
-        url = config.get_inventory_database_url()
+    global _inventory_conn, _inventory_url
+    url = config.get_inventory_database_url()
+    if _inventory_conn is None or _inventory_url != url:
         _inventory_conn = _connect(url)
         _init_inventory_db(_inventory_conn)
+        _inventory_url = url
     return _inventory_conn
 
 
 def get_product_db() -> Connection:
     """Return the products database connection."""
 
-    global _product_conn
-    if _product_conn is None:
-        url = config.get_product_database_url()
+    global _product_conn, _product_url
+    url = config.get_product_database_url()
+    if _product_conn is None or _product_url != url:
         _product_conn = _connect(url)
         _init_product_db(_product_conn)
+        _product_url = url
     return _product_conn
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,24 @@ def test_cli_update_extra_and_serve(monkeypatch, tmp_db):
 
 
 def test_cli_add_upc_flow(monkeypatch, tmp_db):
-    inputs = iter(["Granola", "16 oz", '{"calories": 100}', "2"])
+    inputs = iter(
+        [
+            "Granola",
+            "16 oz",
+            "1/4 cup",
+            "100",
+            "1g",
+            "0g",
+            "0g",
+            "10mg",
+            "20g",
+            "3g",
+            "5g",
+            "2g",
+            "5g",
+            "2",
+        ]
+    )
 
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     outputs = run_cli(["add", "--upc", "999"], monkeypatch, tmp_db)
@@ -116,3 +133,31 @@ def test_cli_add_upc_flow(monkeypatch, tmp_db):
     for out in outputs:
         assert out["product_info"]["upc"] == "999"
         assert out["product_info"]["nutrition"]["package_size"] == "454 g"
+        assert out["product_info"]["nutrition"]["facts"]["calories"] == 100
+
+
+def test_cli_add_prompt_for_upc(monkeypatch, tmp_db):
+    inputs = iter(
+        [
+            "999",
+            "Granola",
+            "16 oz",
+            "1/4 cup",
+            "100",
+            "1g",
+            "0g",
+            "0g",
+            "10mg",
+            "20g",
+            "3g",
+            "5g",
+            "2g",
+            "5g",
+            "1",
+        ]
+    )
+
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    outputs = run_cli(["add"], monkeypatch, tmp_db)
+    assert len(outputs) == 1
+    assert outputs[0]["product_info"]["upc"] == "999"


### PR DESCRIPTION
## Summary
- add prompts for UPC and detailed nutrition facts when missing
- ensure new database connections when env vars change
- update CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505fd2938c8325b1d626ca434d4a85