### PR TITLE
Add interactive UPC flow to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The project uses SQLite to store product and inventory information.
    app using `python -m src.cli.main`.
 5. Visit `http://localhost:3000/health` to verify the service is running.
 6. (Optional) Seed example data with `python3 scripts/seeds.py`.
-7. Retrieve the current inventory with `curl http://localhost:3000/items`.
+7. Retrieve the current inventory with `curl http://localhost:3000/inventory`.
 8. Run `python3 scripts/backup.py` to create a timestamped backup in the
    directory specified by `BACKUP_DIR`. See the [Backups section](docs/usage.md#backups)
    in the usage guide for more details. To automate backups with cron,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,20 +20,20 @@ python -m src.cli.main serve
 
 With the server running, you can interact with the REST endpoints. Examples:
 
-- List items: `GET /items`
+- List items: `GET /inventory`
 - Create item:
   ```bash
-  curl -X POST http://localhost:3000/items \
+  curl -X POST http://localhost:3000/inventory \
     -H 'Content-Type: application/json' \
     -d '{"product": 1, "quantity": 1}'
   ```
  - Update item:
   ```bash
-  curl -X PATCH http://localhost:3000/items/<id> \
+  curl -X PATCH http://localhost:3000/inventory/<id> \
     -H 'Content-Type: application/json' \
     -d '{"quantity": 3}'
   ```
-- Delete item: `DELETE /items/<id>`
+- Delete item: `DELETE /inventory/<id>`
 
 The API also exposes a `/health` endpoint for a simple status check.
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -48,7 +48,7 @@ async def health(db: Connection = Depends(inventory_conn)) -> JSONResponse:
         raise HTTPException(status_code=500, detail=str(exc))
 
 
-@app.get("/items")
+@app.get("/inventory")
 async def list_items(
     inv_db: Connection = Depends(inventory_conn),
     prod_db: Connection = Depends(product_conn),
@@ -60,7 +60,7 @@ async def list_items(
     )
 
 
-@app.post("/items", status_code=201)
+@app.post("/inventory", status_code=201)
 async def create_item(
     data: ItemCreate,
     inv_db: Connection = Depends(inventory_conn),
@@ -74,7 +74,7 @@ async def create_item(
     )
 
 
-@app.patch("/items/{id}")
+@app.patch("/inventory/{id}")
 async def update_item(
     id: Any,
     data: ItemUpdate,
@@ -93,7 +93,7 @@ async def update_item(
     return product
 
 
-@app.delete("/items/{id}")
+@app.delete("/inventory/{id}")
 async def delete_item(id: Any, inv_db: Connection = Depends(inventory_conn)) -> Any:
     deleted = await run_in_threadpool(
         item_service.delete_item,

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -11,6 +11,8 @@ from src import config
 
 _inventory_conn: Optional[Connection] = None
 _product_conn: Optional[Connection] = None
+_inventory_url: Optional[str] = None
+_product_url: Optional[str] = None
 
 
 def _init_product_db(conn: Connection) -> None:
@@ -68,22 +70,24 @@ def _connect(url: str) -> Connection:
 def get_inventory_db() -> Connection:
     """Return the inventory database connection."""
 
-    global _inventory_conn
-    if _inventory_conn is None:
-        url = config.get_inventory_database_url()
+    global _inventory_conn, _inventory_url
+    url = config.get_inventory_database_url()
+    if _inventory_conn is None or _inventory_url != url:
         _inventory_conn = _connect(url)
         _init_inventory_db(_inventory_conn)
+        _inventory_url = url
     return _inventory_conn
 
 
 def get_product_db() -> Connection:
     """Return the products database connection."""
 
-    global _product_conn
-    if _product_conn is None:
-        url = config.get_product_database_url()
+    global _product_conn, _product_url
+    url = config.get_product_database_url()
+    if _product_conn is None or _product_url != url:
         _product_conn = _connect(url)
         _init_product_db(_product_conn)
+        _product_url = url
     return _product_conn
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ def test_product_api_crud(db_conn):
 
     # create inventory product
     resp = client.post(
-        "/items",
+        "/inventory",
         json={
             "product": prod_info["id"],
             "quantity": 1,
@@ -44,13 +44,13 @@ def test_product_api_crud(db_conn):
     item_id = item["id"]
 
     # list products
-    resp = client.get("/items")
+    resp = client.get("/inventory")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
     # update container
     resp = client.patch(
-        f"/items/{item_id}",
+        f"/inventory/{item_id}",
         json={"quantity": 2, "tags": ["baked", "fresh"]},
     )
     assert resp.status_code == 200
@@ -59,11 +59,11 @@ def test_product_api_crud(db_conn):
     assert data["tags"] == ["baked", "fresh"]
 
     # delete product
-    resp = client.delete(f"/items/{item_id}")
+    resp = client.delete(f"/inventory/{item_id}")
     assert resp.status_code == 200
     assert resp.json()["message"] == "Item deleted"
 
     # verify deleted
-    assert client.get("/items").json() == []
+    assert client.get("/inventory").json() == []
 
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add prompts for UPC and detailed nutrition facts when missing
- ensure new database connections when env vars change
- update CLI tests for interactive UPC flow
- handle Ctrl+C gracefully and use editable input prompts
- rename `/items` API endpoints to `/inventory`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68505fd2938c8325b1d626ca434d4a85