### PR TITLE
Update setup script to force service refresh

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,7 +10,9 @@
    pip install -r requirements.txt
    ```
 4. Copy `.env.example` to `.env` and adjust paths if necessary. The defaults place the JSONL data files under `data/`.
-5. Run the setup script to create or update the database and systemd service:
+5. Run the setup script to create or update the database and systemd service.
+   The script stops and removes any existing `foodadmin` unit so updates are
+   applied correctly:
    ```bash
    python3 scripts/setup.py
    ```

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -63,9 +63,9 @@ def create_service() -> None:
     )
     action = "Created"
     if os.path.isfile(SERVICE_FILE):
-        with open(SERVICE_FILE) as f:
-            if expected_exec in f.read():
-                return
+        subprocess.run(["sudo", "systemctl", "stop", "foodadmin"], check=False)
+        subprocess.run(["sudo", "systemctl", "disable", "foodadmin"], check=False)
+        subprocess.run(["sudo", "rm", "-f", SERVICE_FILE])
         action = "Updated"
 
     service_content = textwrap.dedent(


### PR DESCRIPTION
## Summary
- stop and remove any existing `foodadmin` systemd service before writing new unit
- document that the setup script replaces old services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507646daf48325a5575c487e550908