### PR TITLE
Fix default product db path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The project stores product and inventory data in simple JSON Lines files.
 1. Clone this repository.
 2. Copy `.env.example` to `.env` and adjust the paths if desired. The default
    configuration stores data locally under the `data/` directory using JSONL
-   files at `data/inventory.ndjson` and `data/products.jsonl`.
+   files at `data/inventory.ndjson` and `data/product-info.ndjson`.
 3. Run `python3 scripts/setup.py` to install dependencies and create or update
    the systemd service. The script also creates the data files if they do
    not exist. The `requirements.txt` file pins `httpx` to versions

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,7 @@ def get_inventory_database_url() -> str:
 
 def get_product_database_url() -> str:
     """Return the configured products data file."""
-    default_path = get_data_dir() / "products.jsonl"
+    default_path = get_data_dir() / "product-info.ndjson"
     return os.environ.get("PRODUCT_DATABASE_URL", str(default_path))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,5 +17,5 @@ def inventory_db(tmp_path) -> Generator[JsonlDB, None, None]:
 
 @pytest.fixture()
 def product_db(tmp_path) -> Generator[JsonlDB, None, None]:
-    db = JsonlDB(tmp_path / "products.jsonl")
+    db = JsonlDB(tmp_path / "product-info.ndjson")
     yield db


### PR DESCRIPTION
## Summary
- default to `product-info.ndjson` for product database
- update docs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507f312ea88325bf99fa207a122077