### PR TITLE
Add micronutrients support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project stores product and inventory data in simple JSON Lines files.
 
 ### Product Info
 - `name` - product name
-- `nutrition` - nutritional details
+- `nutrition` - nutritional details, including vitamins and minerals
 - `upc` - UPC identifier
 - `uuid` - unique identifier
 
@@ -23,6 +23,16 @@ The project stores product and inventory data in simple JSON Lines files.
 - `location` - where the item is stored
 - `tags` - labels for categorization
 - `container_weight` - weight of the empty container
+
+### Supported Nutrition Fields
+
+The `nutrition` object accepts standard keys such as `calories`, `total_fat`,
+and `protein`. It also supports micronutrients including:
+
+`vitamin_a`, `vitamin_c`, `vitamin_k`, `thiamin_b1`, `riboflavin_b2`,
+`vitamin_b6`, `vitamin_b12`, `folate`, `biotin`, `pantothenic_acid`,
+`phosphorus`, `magnesium`, `selenium`, `manganese`, `molybdenum`, `iodine`,
+`zinc`, `copper`, and `chromium`.
 
 ## Prerequisites
 

--- a/src/services/product_info_service.py
+++ b/src/services/product_info_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
+from src.utils.nutrition import filter_nutrition
+
 import shortuuid
 
 from src.db import JsonlDB
@@ -28,7 +30,7 @@ def create_product_info(db: JsonlDB, data: Dict[str, Any]) -> Dict[str, Any]:
         "name": data.get("name"),
         "upc": data.get("upc"),
         "uuid": data.get("uuid", shortuuid.uuid()),
-        "nutrition": data.get("nutrition"),
+        "nutrition": filter_nutrition(data.get("nutrition")),
     }
     rows.append(item)
     db.write_all(rows)
@@ -62,7 +64,10 @@ def update_product_info(
     updated = None
     for row in rows:
         if row.get("id") == int(id_):
-            row.update(data)
+            row_update = data.copy()
+            if "nutrition" in row_update:
+                row_update["nutrition"] = filter_nutrition(row_update["nutrition"])
+            row.update(row_update)
             updated = row
             break
     if updated is None:

--- a/src/utils/nutrition.py
+++ b/src/utils/nutrition.py
@@ -1,0 +1,53 @@
+"""Helpers for validating nutrition data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Supported nutrient keys including micronutrients
+NUTRIENT_FIELDS = {
+    "serving_size",
+    "calories",
+    "total_fat",
+    "saturated_fat",
+    "trans_fat",
+    "cholesterol",
+    "sodium",
+    "total_carbohydrate",
+    "dietary_fiber",
+    "sugars",
+    "added_sugars",
+    "protein",
+    "vitamin_d",
+    "vitamin_e",
+    "niacin",
+    "calcium",
+    "iron",
+    "potassium",
+    "vitamin_a",
+    "vitamin_c",
+    "vitamin_k",
+    "thiamin_b1",
+    "riboflavin_b2",
+    "vitamin_b6",
+    "vitamin_b12",
+    "folate",
+    "biotin",
+    "pantothenic_acid",
+    "phosphorus",
+    "magnesium",
+    "selenium",
+    "manganese",
+    "molybdenum",
+    "iodine",
+    "zinc",
+    "copper",
+    "chromium",
+}
+
+
+def filter_nutrition(info: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return a dictionary containing only supported nutrient keys."""
+    if info is None:
+        return None
+    return {k: v for k, v in info.items() if k in NUTRIENT_FIELDS}

--- a/tests/test_product_info_service.py
+++ b/tests/test_product_info_service.py
@@ -26,3 +26,29 @@ def test_create_list_update_delete_product(product_db):
     result = product_info_service.delete_product_info(product_db, created["id"])
     assert result is True
     assert product_info_service.list_product_info(product_db) == []
+
+
+def test_create_product_with_extra_nutrients(product_db):
+    data = {
+        "name": "Spinach",
+        "upc": "999",
+        "nutrition": {
+            "calories": 23,
+            "vitamin_a": 140,
+            "vitamin_c": 28,
+            "vitamin_k": 500,
+            "unknown": 1,
+        },
+    }
+    created = product_info_service.create_product_info(product_db, data)
+    nutrition = created["nutrition"]
+    assert "unknown" not in nutrition
+    assert nutrition["vitamin_a"] == 140
+    assert nutrition["vitamin_c"] == 28
+
+    updated = product_info_service.update_product_info(
+        product_db,
+        created["id"],
+        {"nutrition": {"vitamin_a": 150, "zinc": 2}},
+    )
+    assert updated["nutrition"] == {"vitamin_a": 150, "zinc": 2}


### PR DESCRIPTION
## Summary
- allow additional vitamins and minerals in product nutrition data
- validate nutrition info via new utility helper
- document supported nutrition fields
- test saving and updating micronutrients

## Testing
- `black src tests --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508610b2748325b1ba12b5135682c2