### PR TITLE
Switch product IDs to UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ See the [docs](docs/) directory for an overview of the architecture, setup instr
 ## Features
 
 The project stores product and inventory data in simple JSON Lines files.
+Product information entries are identified by UUID strings rather than numeric IDs.
 
 ### Product Info
+- `id` - unique product identifier (UUID string)
 - `name` - product name
 - `nutrition` - nutritional details, including vitamins and minerals
 - `upc` - UPC identifier

--- a/src/services/item_service.py
+++ b/src/services/item_service.py
@@ -39,7 +39,7 @@ def create_item(
     nutrition = data.get("nutrition")
     if isinstance(product, dict):
         if product.get("id") is not None:
-            product_id = int(product.get("id"))
+            product_id = str(product.get("id"))
             info = product_info_service.get_product_info_by_id(prod_db, product_id)
             if info is None:
                 raise ValueError("Product not found")
@@ -51,7 +51,7 @@ def create_item(
             name = name or product.get("name")
             nutrition = nutrition or product.get("nutrition")
     elif product is not None:
-        product_id = int(product)
+        product_id = str(product)
         info = product_info_service.get_product_info_by_id(prod_db, product_id)
         if info is None:
             raise ValueError("Product not found")
@@ -117,7 +117,7 @@ def update_item(
                 prod = data["product"]
                 if isinstance(prod, dict):
                     prod = prod.get("id")
-                row["product_id"] = int(prod) if prod is not None else None
+                row["product_id"] = str(prod) if prod is not None else None
             if "quantity" in data:
                 row["quantity"] = data["quantity"]
             if "opened" in data:

--- a/src/services/product_info_service.py
+++ b/src/services/product_info_service.py
@@ -26,7 +26,7 @@ def _next_id(rows: List[Dict[str, Any]]) -> int:
 def create_product_info(db: JsonlDB, data: Dict[str, Any]) -> Dict[str, Any]:
     rows = db.read_all()
     item = {
-        "id": _next_id(rows),
+        "id": shortuuid.uuid(),
         "name": data.get("name"),
         "upc": data.get("upc"),
         "uuid": data.get("uuid", shortuuid.uuid()),
@@ -40,7 +40,7 @@ def create_product_info(db: JsonlDB, data: Dict[str, Any]) -> Dict[str, Any]:
 def get_product_info_by_id(db: JsonlDB, id_: Any) -> Optional[Dict[str, Any]]:
     rows = db.read_all()
     for row in rows:
-        if row.get("id") == int(id_):
+        if str(row.get("id")) == str(id_):
             return _normalize(row)
     return None
 
@@ -63,7 +63,8 @@ def update_product_info(
     rows = db.read_all()
     updated = None
     for row in rows:
-        if row.get("id") == int(id_):
+        if str(row.get("id")) == str(id_):
+
             row_update = data.copy()
             if "nutrition" in row_update:
                 row_update["nutrition"] = filter_nutrition(row_update["nutrition"])
@@ -78,7 +79,7 @@ def update_product_info(
 
 def delete_product_info(db: JsonlDB, id_: Any) -> bool:
     rows = db.read_all()
-    new_rows = [row for row in rows if row.get("id") != int(id_)]
+    new_rows = [row for row in rows if str(row.get("id")) != str(id_)]
     if len(new_rows) == len(rows):
         return False
     db.write_all(new_rows)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,7 +74,7 @@ def test_create_item_requires_upc_via_api(inventory_db, product_db):
     app.dependency_overrides[app_product_conn] = lambda: product_db
     client = TestClient(app)
 
-    resp = client.post("/inventory", json={"product": 1, "quantity": 1})
+    resp = client.post("/inventory", json={"product": "1", "quantity": 1})
     assert resp.status_code == 400
 
     app.dependency_overrides.clear()

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -57,8 +57,7 @@ def test_create_list_update_delete_item(inventory_db, product_db):
 
 def test_update_item_all_fields(inventory_db, product_db):
     prod1 = setup_product(product_db)
-    prod2 = item_service.create_item(
-        product_db,
+    prod2 = product_info_service.create_product_info(
         product_db,
         {"name": "Yogurt", "upc": "789", "uuid": "uuid3", "nutrition": None},
     )
@@ -110,7 +109,7 @@ def test_create_item_requires_upc(inventory_db, product_db):
         item_service.create_item(
             inventory_db,
             product_db,
-            {"product": 1, "quantity": 1},
+            {"product": "1", "quantity": 1},
         )
 
 


### PR DESCRIPTION
## Summary
- generate product_info `id` using `shortuuid.uuid`
- compare product_info ids as strings when updating, fetching or deleting
- treat item `product_id` as a string UUID
- adjust tests for UUID ids
- clarify README that product ids are UUID strings

## Testing
- `black src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509473610483259a8c8109b3c41b3e