### PR TITLE
Implement consume item endpoint

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,12 @@ With the server running, you can interact with the REST endpoints. Examples:
     -d '{"quantity": 3}'
   ```
 - Delete item by UUID: `DELETE /inventory/uuid/<uuid>`
+- Consume amount from an item:
+  ```bash
+  curl -X POST http://localhost:3000/inventory/<id>/consume \
+    -H 'Content-Type: application/json' \
+    -d '{"amount": 0.5}'
+  ```
 
 The API also exposes a `/health` endpoint for a simple status check.
 

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -29,6 +29,10 @@ class ItemUpdate(ItemCreate):
     pass
 
 
+class ConsumeAmount(BaseModel):
+    amount: float
+
+
 app = FastAPI()
 
 
@@ -98,6 +102,25 @@ async def update_item(
     if not product:
         raise HTTPException(status_code=404, detail="Item not found")
     return product
+
+
+@app.post("/inventory/{id}/consume")
+async def consume_item(
+    id: Any,
+    data: ConsumeAmount,
+    inv_db: JsonlDB = Depends(inventory_conn),
+    prod_db: JsonlDB = Depends(product_conn),
+) -> Any:
+    item = await run_in_threadpool(
+        item_service.consume_item,
+        inv_db,
+        prod_db,
+        id,
+        data.amount,
+    )
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
 
 
 @app.delete("/inventory/{id}")

--- a/src/services/item_service.py
+++ b/src/services/item_service.py
@@ -207,3 +207,22 @@ def delete_item_by_uuid(inv_db: JsonlDB, uuid: Any) -> bool:
         return False
     inv_db.write_all(new_items)
     return True
+
+
+def consume_item(
+    inv_db: JsonlDB, prod_db: JsonlDB, id_: Any, amount: float
+) -> Optional[Dict[str, Any]]:
+    """Decrease remaining by amount for the item with the given id."""
+
+    items = inv_db.read_all()
+    updated = None
+    for row in items:
+        if row.get("id") == int(id_):
+            current = row.get("remaining") or 0
+            row["remaining"] = max(0.0, current - amount)
+            updated = row
+            break
+    if updated is None:
+        return None
+    inv_db.write_all(items)
+    return _normalize(prod_db, updated)

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -167,3 +167,17 @@ def test_uuid_helpers(inventory_db, product_db):
     deleted = item_service.delete_item_by_uuid(inventory_db, uuid)
     assert deleted is True
     assert item_service.get_item_by_uuid(inventory_db, product_db, uuid) is None
+
+
+def test_consume_item(inventory_db, product_db):
+    prod = setup_product(product_db)
+    item = item_service.create_item(
+        inventory_db,
+        product_db,
+        {"product": prod["id"], "remaining": 1.0},
+    )
+
+    updated = item_service.consume_item(inventory_db, product_db, item["id"], 0.25)
+    assert updated["remaining"] == 0.75
+    fetched = item_service.get_item_by_id(inventory_db, product_db, item["id"])
+    assert fetched["remaining"] == 0.75


### PR DESCRIPTION
## Summary
- implement `consume_item` in item service
- add `/inventory/{id}/consume` route
- cover consume logic in tests
- document new consume endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685099e79a348325bff82b3458a43bed