### PR TITLE
Update docs on short UUID usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Product information entries are identified by UUID strings rather than numeric I
 - `location` - where the item is stored
 - `tags` - labels for categorization
 - `container_weight` - weight of the empty container
+- each item automatically receives a short UUID for use with QR code stickers or scanners
 
 ### Supported Nutrition Fields
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,11 @@ With the server running, you can interact with the REST endpoints. Examples:
     -d '{"quantity": 3}'
   ```
 - Delete item by UUID: `DELETE /inventory/uuid/<uuid>`
+
+You can print QR code stickers that encode the item's short UUID. Scanning one
+opens `/inventory/uuid/<uuid>` in your client so you can view the item
+instantly. After checking the details, you might issue a `PATCH` request to the
+same URL to update the `remaining` weight if you consumed some of it.
 - Consume amount from an item:
   ```bash
   curl -X POST http://localhost:3000/inventory/<id>/consume \


### PR DESCRIPTION
## Summary
- document short UUIDs for inventory items
- add example of scanning a QR code to look up items by UUID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a8a235bc8325994655c29a36bc0c