### PR TITLE
Add predictable key ordering for product info

### DIFF
--- a/src/services/product_info_service.py
+++ b/src/services/product_info_service.py
@@ -28,9 +28,9 @@ def _next_id(rows: List[Dict[str, Any]]) -> int:
 def create_product_info(db: JsonlDB, data: Dict[str, Any]) -> Dict[str, Any]:
     rows = db.read_all()
     item = {
-        "id": shortuuid.uuid(),
         "name": data.get("name"),
         "upc": data.get("upc"),
+        "id": shortuuid.uuid(),
         "nutrition": filter_nutrition(data.get("nutrition")),
         "tags": data.get("tags"),
     }

--- a/tests/test_product_info_service.py
+++ b/tests/test_product_info_service.py
@@ -55,3 +55,15 @@ def test_create_product_with_extra_nutrients(product_db):
         {"nutrition": {"vitamin_a": 150, "zinc": 2}},
     )
     assert updated["nutrition"] == {"vitamin_a": 150, "zinc": 2}
+
+
+def test_product_key_order(product_db):
+    data = {
+        "name": "Juice",
+        "upc": "321",
+        "nutrition": {"calories": 80},
+        "tags": ["cold"],
+    }
+    product_info_service.create_product_info(product_db, data)
+    record = product_db.read_all()[0]
+    assert list(record.keys()) == ["name", "upc", "id", "nutrition", "tags"]


### PR DESCRIPTION
## Summary
- keep product info keys in the order requested when creating a product
- test that the key order is preserved on disk

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685317a93538832592ece7df9160e277