### PR TITLE
Fix product tags when creating new item

### DIFF
--- a/src/services/inventory_service.py
+++ b/src/services/inventory_service.py
@@ -71,7 +71,13 @@ def create_item(
             if not name:
                 raise ValueError("Name required for unknown UPC")
             new_prod = product_info_service.create_product_info(
-                prod_db, {"name": name, "upc": upc, "nutrition": nutrition}
+                prod_db,
+                {
+                    "name": name,
+                    "upc": upc,
+                    "nutrition": nutrition,
+                    "tags": data.get("tags"),
+                },
             )
             product_id = new_prod["id"]
     data.setdefault("uuid", shortuuid.uuid())

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -181,3 +181,15 @@ def test_consume_item(inventory_db, product_db):
     assert updated["remaining"] == 0.75
     fetched = inventory_service.get_item_by_id(inventory_db, product_db, item["id"])
     assert fetched["remaining"] == 0.75
+
+
+def test_create_item_adds_tags_to_new_product(inventory_db, product_db):
+    tags = ["organic", "snack"]
+    inventory_service.create_item(
+        inventory_db,
+        product_db,
+        {"upc": "99999", "name": "Chips", "tags": tags},
+    )
+
+    prod_info = product_info_service.get_product_info_by_upc(product_db, "99999")
+    assert prod_info["tags"] == tags


### PR DESCRIPTION
## Summary
- include tags when auto-creating product info
- ensure new product tags persist when created via create_item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853183ea0bc8325bf72a5b194724177