### PR TITLE
Update peanut butter quantity in simulate_entry script

### DIFF
--- a/tests/simulate_entry.sh
+++ b/tests/simulate_entry.sh
@@ -19,7 +19,7 @@ BASE_URL="http://localhost:${PORT}"
 echo "Adding peanut butter to inventory using only UPC..."
 pb_response=$(curl -s -X POST "${BASE_URL}/inventory" \
     -H 'Content-Type: application/json' \
-    -d '{"upc": "051500245453"}')
+    -d '{"upc": "051500245453", "quantity": 2}')
 
 if [[ $? == 0 ]]; then
     echo "$pb_response"


### PR DESCRIPTION
## Summary
- specify quantity 2 when adding peanut butter by UPC in `tests/simulate_entry.sh`

## Testing
- `black -q src tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532bb6f8c88325ae886fbc8a7f94f4