### PR TITLE
Update peanut butter quantity test and script error handling

### DIFF
--- a/tests/simulate_entry.sh
+++ b/tests/simulate_entry.sh
@@ -17,9 +17,9 @@ BASE_URL="http://localhost:${PORT}"
 
 # Add Jif Creamy Peanut Butter Pouch by UPC
 echo "Adding peanut butter to inventory using only UPC..."
-pb_response=$(curl -s -X POST "${BASE_URL}/inventory" \
+pb_response=$(curl -s -f -X POST "${BASE_URL}/inventory" \
     -H 'Content-Type: application/json' \
-    -d '{"upc": "051500245453"}')
+    -d '{"upc": "051500245453", "quantity": 2}')
 
 if [[ $? == 0 ]]; then
     echo "$pb_response"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,6 +96,24 @@ def test_create_item_with_upc_lookup_via_api(inventory_db, product_db):
     app.dependency_overrides.clear()
 
 
+def test_create_item_with_quantity_two_via_api(inventory_db, product_db):
+    app.dependency_overrides[app_inventory_conn] = lambda: inventory_db
+    app.dependency_overrides[app_product_conn] = lambda: product_db
+    client = TestClient(app)
+
+    prod = product_info_service.create_product_info(
+        product_db, {"name": "Peanut Butter", "upc": "051500245453"}
+    )
+
+    resp = client.post("/inventory", json={"upc": prod["upc"], "quantity": 2})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["quantity"] == 2
+    assert data["product_info"]["id"] == prod["id"]
+
+    app.dependency_overrides.clear()
+
+
 def test_create_item_unknown_upc_needs_name_via_api(inventory_db, product_db):
     app.dependency_overrides[app_inventory_conn] = lambda: inventory_db
     app.dependency_overrides[app_product_conn] = lambda: product_db


### PR DESCRIPTION
## Summary
- add API test to confirm quantity 2 works
- fail fast in `simulate_entry.sh` when API returns an error

## Testing
- `black -q src tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532bb6f8c88325ae886fbc8a7f94f4