### PR TITLE
Fix quantity in inventory API

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -20,6 +20,7 @@ class ItemCreate(BaseModel):
     opened: Optional[bool] = None
     weight_g: Optional[int] = None
     expiration_date: Optional[str] = None
+    quantity: Optional[int] = None
     tags: Optional[List[str]] = None
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,3 +41,20 @@ def test_create_and_list(inventory_db, product_db):
     assert result[0]["product_id"] == prod["product_id"]
 
     app.dependency_overrides.clear()
+
+
+def test_create_item_with_quantity(inventory_db, product_db):
+    app.dependency_overrides[app_inventory_conn] = lambda: inventory_db
+    app.dependency_overrides[app_product_conn] = lambda: product_db
+    client = TestClient(app)
+
+    prod = setup_product(product_db)
+    resp = client.post(
+        "/inventory",
+        json={"product": prod["product_id"], "quantity": 2},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data["units"]) == 2
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- allow `quantity` field in `ItemCreate` model so multiple units can be created
- test creating inventory items with quantity

## Testing
- `black -q src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68534ef59e20832597f60632eca24d97